### PR TITLE
Remove auto focus when not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const TerminalController = (props = {}) => {
 | lineData      | Terminal line data to render. Line type is either `Output` or `Input`; Line data with `LineType.Input` will display with a prompt before the line. |
 | onInput       | A callback function that is invoked when a user presses enter on the prompt. The function is passed the current prompt input. |
 | prompt        | The prompt character. Default to '$' |
+| autoFocus     | Make the terminal focus automatic when click on the page |
 
 ### Development
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ export enum ColorMode {
 export interface Props {
   name?: string
   prompt?: string
+  autoFocus?: boolean;
   colorMode?: ColorMode
   lineData: Array<{type: LineType, value: string}>
   onInput: ((input: string) => void) | null | undefined
@@ -42,7 +43,9 @@ const Terminal = (props: Props) => {
 
   // We use a hidden input to capture terminal input; make sure the hidden input is focused when clicking anywhere on the document
   useEffect(() => {
-    document.onclick = () => document.getElementById("terminal-hidden")?.focus()
+    if(props.autoFocus) {
+        document.onclick = () => document.getElementById("terminal-hidden")?.focus()
+    }
   });
 
   const renderedLineData = props.lineData.map((ld, i) => {


### PR DESCRIPTION
Hi, Thanks for the lib, work perfect! I only have one problem with the auto focus, when click in the page on other element  always focus the terminal and scroll the page. For me is working fine I hope can be usefully for others.