### PR TITLE
Fix for scroll to view for multiple terminals

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ const Terminal = ({name, prompt, colorMode, onInput, children, startingInputValu
   const performScrolldown = useRef(false);
   useEffect(() => {
     if (performScrolldown.current) { // skip scrolldown when the component first loads
-      setTimeout(() => scrollIntoViewRef?.current?.scrollIntoView({ behavior: "smooth", block: "nearest" }), 500);
+      setTimeout(() => scrollIntoViewRef?.current?.scrollIntoView({ behavior: "auto", block: "nearest" }), 500);
     }
     performScrolldown.current = true;
   }, [children]);


### PR DESCRIPTION
for some reason google chrome with `ScrollIntoView:"smooth"`, doesnt work with multiple terminals open.

reference: https://stackoverflow.com/questions/66586455/why-doesnt-scrollintoview-work-on-two-simultaneous-elements 