### PR TITLE
Add support for left/right arrows to move terminal line cursor

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,7 +65,7 @@ const Terminal = ({name, prompt, height = "600px", colorMode, onInput, children,
 
       if(event.key === 'ArrowLeft') {
         if(cursorIndex > currentLineInput.length - 1) cursorIndex --;
-        charsToRightOfCursor = currentLineInput.slice(currentLineInput.length -1 - cursorIndex); // 4 - 5
+        charsToRightOfCursor = currentLineInput.slice(currentLineInput.length -1 - cursorIndex);
       }
       else if (event.key === 'ArrowRight' || event.key === 'Delete') {
         charsToRightOfCursor = currentLineInput.slice(currentLineInput.length - cursorIndex + 1);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,10 +29,6 @@ const Terminal = ({name, prompt, height = "600px", colorMode, onInput, children,
   }
 
   const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-  
-    }
-
     if (onInput != null && event.key === 'Enter') {
       onInput(currentLineInput);
       setCurrentLineInput('');
@@ -47,7 +43,10 @@ const Terminal = ({name, prompt, height = "600px", colorMode, onInput, children,
     setCursorIndex(cursorIndex)
   }
 
+  // Calculates the total width in pixels of the input field's suffix text.
+  // starting from the cursor position until the end of the input
   const calculateInputWidth = (cursor: HTMLElement, inputElement: HTMLInputElement, inputSuffix: string) => {
+    // Create a temporary span element to measure the width of the input suffix text.
     const span = document.createElement('span');
     span.style.visibility = 'hidden';
     span.style.position = 'absolute';
@@ -57,6 +56,7 @@ const Terminal = ({name, prompt, height = "600px", colorMode, onInput, children,
     document.body.appendChild(span);
     const width = span.getBoundingClientRect().width;
     document.body.removeChild(span);
+    // Return the negative width, since the cursor position is to the left of the input suffix
     return -width;
   };
 
@@ -79,8 +79,8 @@ const Terminal = ({name, prompt, height = "600px", colorMode, onInput, children,
     setCurrentLineInput(startingInputValue.trim());
   }, [startingInputValue]);
 
+  // Update cursor position 60 times a second.
   useEffect(() => {
-    // Update cursor position 60 times a second.
     const interval = setInterval(() => {
       updateCursorPosition();
     }, 1000 / 60);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,6 +56,7 @@ const Terminal = ({name, prompt, height = "600px", colorMode, onInput, children,
     };
     if (event.key === 'Enter') {
       onInput(currentLineInput);
+      setCursorPos(0);
       setCurrentLineInput('');
     } else if (["ArrowLeft", "ArrowRight", "ArrowDown", "ArrowUp", "Delete"].includes(event.key)) { 
       const inputElement = document.getElementById('hidden') as HTMLInputElement;
@@ -119,7 +120,7 @@ const Terminal = ({name, prompt, height = "600px", colorMode, onInput, children,
     <div className={ classes.join(' ') } data-terminal-name={ name }>
       <div className="react-terminal" style={ { height } }>
         { children }
-        { onInput && <div className="react-terminal-line react-terminal-input react-terminal-active-input" data-terminal-prompt={ prompt || '$' } key="terminal-line-prompt" >{ currentLineInput }<span id="cursor" style={{ position: 'relative', left: `${cursorPos}px` }}></span></div> }
+        { onInput && <div className="react-terminal-line react-terminal-input react-terminal-active-input" data-terminal-prompt={ prompt || '$' } key="terminal-line-prompt" >{ currentLineInput }<span id="cursor" style={{ left: `${cursorPos+1}px` }}></span></div> }
         <div ref={ scrollIntoViewRef }></div>
       </div>
       <input id="hidden" className="terminal-hidden-input" placeholder="Terminal Hidden Input" value={ currentLineInput } autoFocus={ onInput != null } onChange={ updateCurrentLineInput } onKeyDown={ handleInputKeyDown }/>

--- a/src/style.css
+++ b/src/style.css
@@ -83,21 +83,24 @@
   content: attr(data-terminal-prompt);
 }
 
-.react-terminal-wrapper:focus-within .react-terminal-active-input #cursor:after {
-  content: '▋';
+.react-terminal-wrapper:focus-within .react-terminal-active-input #cursor {
   position: relative;
-  font-family: monospace;
+  display: inline-block;
+  width: 0.55em;
+  height: 1em;
+  top: 0.225em;
+  background: #fff;
   -webkit-animation: blink 1s infinite;
           animation: blink 1s infinite;
 }
 
-/* .react-terminal-wrapper:focus-within .react-terminal-active-input:after {
-  content: '▋';
+.react-terminal-wrapper:focus-within .react-terminal-active-input #cursor:after {
+  /* content: '▋';
+  position: relative;
   font-family: monospace;
-  margin-left: 0.2em;
   -webkit-animation: blink 1s infinite;
-          animation: blink 1s infinite;
-} */
+          animation: blink 1s infinite; */
+}
 
 /* Cursor animation */
 

--- a/src/style.css
+++ b/src/style.css
@@ -83,13 +83,21 @@
   content: attr(data-terminal-prompt);
 }
 
-.react-terminal-wrapper:focus-within .react-terminal-active-input:after {
+.react-terminal-wrapper:focus-within .react-terminal-active-input #cursor:after {
+  content: '▋';
+  position: relative;
+  font-family: monospace;
+  -webkit-animation: blink 1s infinite;
+          animation: blink 1s infinite;
+}
+
+/* .react-terminal-wrapper:focus-within .react-terminal-active-input:after {
   content: '▋';
   font-family: monospace;
   margin-left: 0.2em;
   -webkit-animation: blink 1s infinite;
           animation: blink 1s infinite;
-}
+} */
 
 /* Cursor animation */
 

--- a/src/style.css
+++ b/src/style.css
@@ -94,14 +94,6 @@
           animation: blink 1s infinite;
 }
 
-.react-terminal-wrapper:focus-within .react-terminal-active-input #cursor:after {
-  /* content: '▋';
-  position: relative;
-  font-family: monospace;
-  -webkit-animation: blink 1s infinite;
-          animation: blink 1s infinite; */
-}
-
 /* Cursor animation */
 
 @-webkit-keyframes blink {


### PR DESCRIPTION
This PR is in relation to issue #36 
- Changes the Cursor to its own span element.
- Cursor's position set to relative, and left property is being controlled by the position of the cursor inside the hidden terminal input element. 
- Works with any font size or font family