### PR TITLE
Fix 39 remove id attributes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,7 +59,7 @@ const Terminal = ({name, prompt, height = "600px", colorMode, onInput, children,
       setCursorPos(0);
       setCurrentLineInput('');
     } else if (["ArrowLeft", "ArrowRight", "ArrowDown", "ArrowUp", "Delete"].includes(event.key)) { 
-      const inputElement = document.getElementById('hidden') as HTMLInputElement;
+      const inputElement = event.currentTarget;
       let charsToRightOfCursor = "";
       let cursorIndex = currentLineInput.length - (inputElement.selectionStart || 0);
       cursorIndex = clamp(cursorIndex, 0, currentLineInput.length);
@@ -120,10 +120,10 @@ const Terminal = ({name, prompt, height = "600px", colorMode, onInput, children,
     <div className={ classes.join(' ') } data-terminal-name={ name }>
       <div className="react-terminal" style={ { height } }>
         { children }
-        { onInput && <div className="react-terminal-line react-terminal-input react-terminal-active-input" data-terminal-prompt={ prompt || '$' } key="terminal-line-prompt" >{ currentLineInput }<span id="cursor" style={{ left: `${cursorPos+1}px` }}></span></div> }
+        { onInput && <div className="react-terminal-line react-terminal-input react-terminal-active-input" data-terminal-prompt={ prompt || '$' } key="terminal-line-prompt" >{ currentLineInput }<span className="cursor" style={{ left: `${cursorPos+1}px` }}></span></div> }
         <div ref={ scrollIntoViewRef }></div>
       </div>
-      <input id="hidden" className="terminal-hidden-input" placeholder="Terminal Hidden Input" value={ currentLineInput } autoFocus={ onInput != null } onChange={ updateCurrentLineInput } onKeyDown={ handleInputKeyDown }/>
+      <input className="terminal-hidden-input" placeholder="Terminal Hidden Input" value={ currentLineInput } autoFocus={ onInput != null } onChange={ updateCurrentLineInput } onKeyDown={ handleInputKeyDown }/>
     </div>
   );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -83,7 +83,7 @@
   content: attr(data-terminal-prompt);
 }
 
-.react-terminal-wrapper:focus-within .react-terminal-active-input #cursor {
+.react-terminal-wrapper:focus-within .react-terminal-active-input .cursor {
   position: relative;
   display: inline-block;
   width: 0.55em;


### PR DESCRIPTION
This PR fixes the issue in #39 . Thanks for your comments- no need for refs here at all, using `event.target` instead. Also removing id's (cursor is now a class to apply CSS styles).