### PR TITLE
Fix code snippet in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const TerminalController = (props = {}) => {
       </Terminal>
     </div>
   )
-});
+};
 ```
 
 ## Component Props


### PR DESCRIPTION
The example code snippet contained a stray closing bracket that caused it not to compile.